### PR TITLE
Fix python 3.6 tests failing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,12 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9]
-    runs-on: ubuntu-latest
+        include:
+          - os: ubuntu-latest
+          # There is no build for Python 3.6 in ubuntu>20.04.
+          - os: ubuntu-20.04
+            python: 3.6
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{matrix.python}}


### PR DESCRIPTION
This PR fixes an issue where CI fails even if all tests should be passing.

Python 3.6 tests are failing because 3.6 is no longer supported on the current `ubuntu-latest` version `ubuntu-22.04` (see https://github.com/actions/setup-python/issues/544).

This PR makes the python 3.6 tests run on `ubuntu-20.04` which still supports 3.6.

I referenced the [GitHub Actions Documentation](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations) and [this commit](https://github.com/predicthq/sdk-py/commit/d52ff9662d6c0f9c3a4699392d49b9559bbc9e92) when making these changes to the workflow job.

People might have to [git merge](https://www.atlassian.com/git/tutorials/using-branches/git-merge) or [git rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase) if they have already pushed their work.